### PR TITLE
Actor Critic Batch advantages

### DIFF
--- a/adept/agents/__init__.py
+++ b/adept/agents/__init__.py
@@ -24,7 +24,8 @@ AGENTS = {
 }
 AGENT_ARGS = {
     'ActorCritic': lambda args: (
-        args.nb_env, args.exp_length, args.discount, args.generalized_advantage_estimation, args.tau
+        args.nb_env, args.exp_length, args.discount, args.generalized_advantage_estimation,
+        args.tau, args.normalize_advantage
     ),
     'ActorCriticVtrace': lambda args: (args.nb_env, args.exp_length, args.discount),
 }

--- a/adept/utils/script_helpers.py
+++ b/adept/utils/script_helpers.py
@@ -189,6 +189,10 @@ def add_base_args(parser):
     Agent Arguments
     """
     parser.add_argument(
+        '-na', '--normalize-advantage', type=parse_bool, nargs='?', const=True, default=False,
+        help='normalize the advantage'
+    )
+    parser.add_argument(
         '-gae', '--generalized-advantage-estimation', type=parse_bool, nargs='?', const=True, default=True,
         help='use generalized advantage estimation'
     )


### PR DESCRIPTION
Initially this was meant for the critic target to be the GAE return but that performs worse in testing and according to the original authors offers no improvement. This branch just adds batch calculating of the nstep advantages and a new optional flag to normalize the advantage for the policy (which can help or hurt depending on the environment/network)