### PR TITLE
Reformat script arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,15 +66,15 @@ The log directory contains the tensorboard file, saved models, and other metadat
 ```
 # Local Mode (A2C)
 # We recommend 4GB+ GPU memory, 8GB+ RAM, 4+ Cores
-python -m adept.scripts.local --env-id BeamRiderNoFrameskip-v4
+python -m adept.scripts.local ActorCritic --env-id BeamRiderNoFrameskip-v4
 
 # Towered Mode (A3C Variant, requires mpi4py)
 # We recommend 2+ GPUs, 8GB+ GPU memory, 32GB+ RAM, 4+ Cores
-python -m adept.scripts.towered --env-id BeamRiderNoFrameskip-v4
+python -m adept.scripts.towered ActorCritic --env-id BeamRiderNoFrameskip-v4
 
 # IMPALA (requires mpi4py and is resource intensive)
 # We recommend 2+ GPUs, 8GB+ GPU memory, 32GB+ RAM, 4+ Cores
-mpiexec -n 3 python -m adept.scripts.impala --env-id BeamRiderNoFrameskip-v4
+mpiexec -n 3 python -m adept.scripts.impala ActorCriticVtrace --env-id BeamRiderNoFrameskip-v4
 
 # StarCraft 2 (IMPALA not supported yet)
 # Warning: much more resource intensive than Atari

--- a/adept/agents/__init__.py
+++ b/adept/agents/__init__.py
@@ -14,18 +14,73 @@ GNU General Public License for more details.
 You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 """
+from argparse import ArgumentParser  # for type hinting
+from adept.utils.util import parse_bool
 from .actor_critic import ActorCritic
 from .impala import ActorCriticVtrace
 from ._base import EnvBase
 
-AGENTS = {
-    'ActorCritic': ActorCritic,
-    'ActorCriticVtrace': ActorCriticVtrace
-}
+AGENTS = {'ActorCritic': ActorCritic, 'ActorCriticVtrace': ActorCriticVtrace}
 AGENT_ARGS = {
     'ActorCritic': lambda args: (
-        args.nb_env, args.exp_length, args.discount, args.generalized_advantage_estimation,
-        args.tau, args.normalize_advantage
+        args.env_nb, args.exp_length, args.discount, args.generalized_advantage_estimation,
+        args.tau, args.normalize_advantage, args.entropy_weight
     ),
-    'ActorCriticVtrace': lambda args: (args.nb_env, args.exp_length, args.discount),
+    'ActorCriticVtrace': lambda args: (args.env_nb, args.exp_length, args.discount),
+}
+
+
+def ActorCritic_ArgParse(parser: ArgumentParser):
+    parser.add_argument(
+        '-ae',
+        '--exp-length',
+        type=int,
+        default=20,
+        help='Experience length (default: 20)'
+    )
+    parser.add_argument(
+        '-ag',
+        '--generalized-advantage-estimation',
+        type=parse_bool,
+        nargs='?',
+        const=True,
+        default=True,
+        help='Use generalized advantage estimation for the policy loss. (default: True)'
+    )
+    parser.add_argument(
+        '-at',
+        '--tau',
+        type=float,
+        default=1.00,
+        help='parameter for GAE (default: 1.00)'
+    )
+    parser.add_argument(
+        '--entropy-weight',
+        type=float,
+        default=0.01,
+        help='Entropy penalty (default: 0.01)'
+    )
+    parser.add_argument(
+        '--normalize-advantage',
+        type=parse_bool,
+        nargs='?',
+        const=True,
+        default=False,
+        help='Normalize the advantage when calculating policy loss. (default: False)'
+    )
+
+
+def ActorCriticVtrace_ArgParse(parser: ArgumentParser):
+    parser.add_argument(
+        '-ae',
+        '--exp-length',
+        type=int,
+        default=20,
+        help='Experience length (default: 20)'
+    )
+
+
+AGENT_ARG_PARSE = {
+    'ActorCritic': ActorCritic_ArgParse,
+    'ActorCriticVtrace': ActorCriticVtrace_ArgParse
 }

--- a/adept/containers/impala.py
+++ b/adept/containers/impala.py
@@ -311,6 +311,7 @@ class ImpalaWorker(HasAgent, HasEnvironment, LogsAndSummarizesRewards, MPIProc):
         return self._summary_writer
 
     def run(self, initial_count=0):
+        self.local_step_count = initial_count
         next_obs = self.environment.reset()
         self._starting_internals = self.agent.internals
         while not self.should_stop():

--- a/adept/containers/towered.py
+++ b/adept/containers/towered.py
@@ -301,6 +301,7 @@ class ToweredWorker(HasAgent, HasEnvironment, WritesSummaries, LogsAndSummarizes
         return self._nb_env
 
     def run(self, initial_count=0):
+        self.local_step_count = initial_count
         next_obs = self.environment.reset()
         self.start_time = time.time()
         while not self.should_stop():
@@ -344,7 +345,7 @@ class ToweredWorker(HasAgent, HasEnvironment, WritesSummaries, LogsAndSummarizes
         if host_info is not None:
             self.global_step = host_info
         else:
-            self.global_step = 0
+            self.global_step = self.local_step_count
         # host decides when it wants pytorch buffers
         if self.mpi_buffer_request.test()[0]:
             buffer_list = [x.cpu().numpy() for x in self.network._all_buffers()]

--- a/adept/scripts/evaluation.py
+++ b/adept/scripts/evaluation.py
@@ -53,7 +53,7 @@ def main(args):
 
     with open(os.path.join(args.log_id_dir, 'args.json'), 'r') as args_file:
         train_args = dotdict(json.load(args_file))
-    train_args.nb_env = 1
+    train_args.env_nb = 1
 
     # construct env
     def env_fn(seed):

--- a/adept/scripts/render.py
+++ b/adept/scripts/render.py
@@ -33,7 +33,7 @@ def main(args):
 
     with open(args.args_file, 'r') as args_file:
         train_args = dotdict(json.load(args_file))
-    train_args.nb_env = 1
+    train_args.env_nb = 1
 
     # construct env
     def env_fn(seed):

--- a/adept/scripts/replay_gen.py
+++ b/adept/scripts/replay_gen.py
@@ -39,7 +39,7 @@ def main(args):
 
     with open(args.args_file, 'r') as args_file:
         train_args = dotdict(json.load(args_file))
-    train_args.nb_env = 1
+    train_args.env_nb = 1
 
     # construct env
     replay_dir = os.path.split(args.network_file)[0]

--- a/adept/scripts/resume_local.py
+++ b/adept/scripts/resume_local.py
@@ -43,7 +43,7 @@ def main(args):
         args = dotdict(json.load(args_file))
 
     print_ascii_logo()
-    log_id = make_log_id(args.tag, args.mode_name, args.agent, args.vision_network + args.network_body)
+    log_id = make_log_id(args.tag, args.mode_name, args.agent, args.network_vision + args.network_body)
     log_id_dir = os.path.join(args.log_dir, args.env_id, log_id)
 
     os.makedirs(log_id_dir)
@@ -82,7 +82,7 @@ def main(args):
         env,
         make_optimizer,
         args.epoch_len,
-        args.nb_env,
+        args.env_nb,
         logger,
         summary_writer,
         args.summary_frequency,

--- a/adept/scripts/towered.py
+++ b/adept/scripts/towered.py
@@ -16,7 +16,7 @@ You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 """
 import os
-from copy import deepcopy 
+from copy import deepcopy
 import torch
 from absl import flags
 from mpi4py import MPI as mpi
@@ -42,9 +42,10 @@ def main(args):
     # host needs to broadcast timestamp so all procs create the same log dir
     if rank == 0:
         timestamp = datetime.now().strftime('%Y-%m-%d_%H-%M-%S')
-        log_id = make_log_id_from_timestamp(args.tag, args.mode_name, args.agent,
-                                            args.vision_network + args.network_body,
-                                            timestamp)
+        log_id = make_log_id_from_timestamp(
+            args.tag, args.mode_name, args.agent,
+            args.network_vision + args.network_body, timestamp
+        )
         log_id_dir = os.path.join(args.log_dir, args.env_id, log_id)
         os.makedirs(log_id_dir)
         saver = SimpleModelSaver(log_id_dir)
@@ -54,19 +55,21 @@ def main(args):
     timestamp = comm.bcast(timestamp, root=0)
 
     if rank != 0:
-        log_id = make_log_id_from_timestamp(args.tag, args.mode_name, args.agent,
-                                            args.vision_network + args.network_body,
-                                            timestamp)
+        log_id = make_log_id_from_timestamp(
+            args.tag, args.mode_name, args.agent,
+            args.network_vision + args.network_body, timestamp
+        )
         log_id_dir = os.path.join(args.log_dir, args.env_id, log_id)
 
     comm.Barrier()
 
     # construct env
-    seed = args.seed if rank == 0 else args.seed + (args.nb_env * (rank - 1))  # unique seed per process
+    # unique seed per process
+    seed = args.seed if rank == 0 else args.seed + args.env_nb * (rank - 1)
     # don't make a ton of envs if host
     if rank == 0:
         env_args = deepcopy(args)
-        env_args.nb_env = 1
+        env_args.env_nb = 1
         env = make_env(env_args, seed)
     else:
         env = make_env(args, seed)
@@ -76,19 +79,33 @@ def main(args):
     network_head_shapes = get_head_shapes(env.action_space, env.engine, args.agent)
     network = make_network(env.observation_space, network_head_shapes, args)
 
-    # sync network params
-    if rank == 0:
-        for v in network.parameters():
-            comm.Bcast(v.detach().cpu().numpy(), root=0)
-        print('Root variables synced')
+    # possibly load network
+    initial_step_count = 0
+    if args.load_network:
+        network.load_state_dict(
+            torch.load(
+                args.load_network, map_location=lambda storage, loc: storage
+            )
+        )
+        # get step count from network file
+        epoch_dir = os.path.split(args.load_network)[0]
+        initial_step_count = int(os.path.split(epoch_dir)[-1])
+        print('Reloaded network from {}'.format(args.load_network))
+
+    # only sync network params if not loading
     else:
-        # can just use the numpy buffers
-        variables = [v.detach().cpu().numpy() for v in network.parameters()]
-        for v in variables:
-            comm.Bcast(v, root=0)
-        for shared_v, model_v in zip(variables, network.parameters()):
-            model_v.data.copy_(torch.from_numpy(shared_v), non_blocking=True)
-        print('{} variables synced'.format(rank))
+        if rank == 0:
+            for v in network.parameters():
+                comm.Bcast(v.detach().cpu().numpy(), root=0)
+            print('Root variables synced')
+        else:
+            # can just use the numpy buffers
+            variables = [v.detach().cpu().numpy() for v in network.parameters()]
+            for v in variables:
+                comm.Bcast(v, root=0)
+            for shared_v, model_v in zip(variables, network.parameters()):
+                model_v.data.copy_(torch.from_numpy(shared_v), non_blocking=True)
+            print('{} variables synced'.format(rank))
 
     # host is rank 0
     if rank != 0:
@@ -111,17 +128,22 @@ def main(args):
         agent = make_agent(network, device, env.engine, env.gpu_preprocessor, args)
 
         # construct container
-        container = ToweredWorker(agent, env, args.nb_env, logger, summary_writer,
-                                  args.summary_frequency)
+        container = ToweredWorker(
+            agent, env, args.env_nb, logger, summary_writer, args.summary_frequency
+        )
 
         # Run the container
         try:
-            container.run()
+            # distribute global step count evenly to workers
+            container.run(initial_count=initial_step_count // (size - 1))
         finally:
             env.close()
     # host
     else:
-        logger = make_logger('ToweredHost', os.path.join(log_id_dir, 'train_log_rank{}.txt'.format(rank)))
+        logger = make_logger(
+            'ToweredHost',
+            os.path.join(log_id_dir, 'train_log_rank{}.txt'.format(rank))
+        )
         log_args(logger, args)
         write_args_file(log_id_dir, args)
         logger.info('Network Parameter Count: {}'.format(count_parameters(network)))
@@ -131,10 +153,21 @@ def main(args):
 
         # Construct the optimizer
         def make_optimizer(params):
-            opt = torch.optim.RMSprop(params, lr=args.learning_rate, eps=1e-5, alpha=0.99)
+            opt = torch.optim.RMSprop(
+                params, lr=args.learning_rate, eps=1e-5, alpha=0.99
+            )
+            if args.load_optimizer:
+                opt.load_state_dict(
+                    torch.load(
+                        args.load_optimizer, map_location=lambda storage, loc: storage
+                    )
+                )
             return opt
 
-        container = ToweredHost(comm, args.num_grads_to_drop, network, make_optimizer, saver, args.epoch_len, logger)
+        container = ToweredHost(
+            comm, args.num_grads_to_drop, network, make_optimizer, saver,
+            args.epoch_len, logger
+        )
 
         # Run the container
         if args.profile:
@@ -148,47 +181,38 @@ def main(args):
             profiler.stop()
             print(profiler.output_text(unicode=True, color=True))
         else:
-            container.run(args.max_train_steps)
+            container.run(args.max_train_steps, initial_step_count=initial_step_count)
 
 
 if __name__ == '__main__':
     import argparse
     from adept.utils.script_helpers import add_base_args, parse_bool
 
-    parser = argparse.ArgumentParser(description='AdeptRL Towered Mode')
-    parser = add_base_args(parser)
-    parser.add_argument('--gpu-id', type=int, nargs='+', default=0, help='Which GPU(s) to use for training (default: 0)')
-    parser.add_argument(
-        '-vn', '--vision-network', default='FourConv',
-        help='name of preset network (default: FourConv)'
-    )
-    parser.add_argument(
-        '-dn', '--discrete-network', default='Identity',
-    )
-    parser.add_argument(
-        '-nb', '--network-body', default='LSTM',
-    )
-    parser.add_argument(
-        '--profile', type=parse_bool, nargs='?', const=True, default=False,
-        help='displays profiling tree after 10e3 steps (default: False)'
-    )
-    parser.add_argument(
-        '--agent', default='ActorCritic',
-        help='name of preset agent (default: ActorCritic)'
-    )
-    parser.add_argument(
-        '--debug', type=parse_bool, nargs='?', const=True, default=False,
-        help='debug mode sends the logs to /tmp/ and overrides number of workers to 3 (default: False)'
-    )
-    parser.add_argument(
-        '--num-grads-to-drop', type=int, default=0,
-        help='The number of gradient receives to drop in a round. https://arxiv.org/abs/1604.00981 recommends dropping'
-             ' 10 percent of gradients for maximum speed (default: 0)'
-    )
-    args = parser.parse_args()
+    base_parser = argparse.ArgumentParser(description='AdeptRL Towered Mode')
+
+    def add_args(parser):
+        parser = parser.add_argument_group('Towered Mode Args')
+        parser.add_argument(
+            '--gpu-id',
+            type=int,
+            nargs='+',
+            default=0,
+            help='Which GPU(s) to use for training (default: 0)'
+        )
+        parser.add_argument(
+            '--num-grads-to-drop',
+            type=int,
+            default=0,
+            help=
+            'The number of gradient receives to drop in a round. https://arxiv.org/abs/1604.00981 recommends dropping'
+            ' 10 percent of gradients for maximum speed (default: 0)'
+        )
+
+    add_base_args(base_parser, add_args)
+    args = base_parser.parse_args()
 
     if args.debug:
-        args.nb_env = 3
+        args.env_nb = 3
         args.log_dir = '/tmp/'
     args.mode_name = 'Towered'
 

--- a/adept/utils/script_helpers.py
+++ b/adept/utils/script_helpers.py
@@ -15,8 +15,9 @@ You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 """
 import os
+from argparse import ArgumentParser  # for type hinting
 
-from adept.agents import AGENTS, AGENT_ARGS
+from adept.agents import AGENTS, AGENT_ARGS, AGENT_ARG_PARSE
 from adept.environments import SubProcEnv, SC2_ENVS, Engines, DummyVecEnv
 from adept.environments import reward_normalizer_by_env_id
 from adept.environments.atari import make_atari_env
@@ -40,9 +41,9 @@ def make_env(args, seed, subprocess=True, render=False):
 
 def sc2_from_args(args, seed, subprocess=True, render=False):
     if subprocess:
-        return SubProcEnv([make_sc2_env(args.env_id, seed + i) for i in range(args.nb_env)], Engines.SC2)
+        return SubProcEnv([make_sc2_env(args.env_id, seed + i) for i in range(args.env_nb)], Engines.SC2)
     else:
-        return DummyVecEnv([make_sc2_env(args.env_id, seed + i, render=render) for i in range(args.nb_env)], Engines.SC2)
+        return DummyVecEnv([make_sc2_env(args.env_id, seed + i, render=render) for i in range(args.env_nb)], Engines.SC2)
 
 
 def atari_from_args(args, seed, subprocess=True):
@@ -55,10 +56,10 @@ def atari_from_args(args, seed, subprocess=True):
                 args.env_id,
                 args.skip_rate,
                 args.max_episode_length,
-                args.zscore_norm_env,
+                args.env_zscore,
                 do_frame_stack,
                 seed + i
-            ) for i in range(args.nb_env)
+            ) for i in range(args.env_nb)
         ], Engines.GYM
     )
     return envs
@@ -79,11 +80,11 @@ def make_network(
     for rank, names in nbr.items():
         for name in names:
             if rank == 1:
-                pathways_by_name[name] = c_networks[args.discrete_network].from_args(ebn[name].shape, args)
+                pathways_by_name[name] = c_networks[args.network_discrete].from_args(ebn[name].shape, args)
             elif rank == 2:
                 raise NotImplementedError('Rank 2 inputs not implemented')
             elif rank == 3:
-                pathways_by_name[name] = chw_networks[args.vision_network].from_args(ebn[name].shape, args)
+                pathways_by_name[name] = chw_networks[args.network_vision].from_args(ebn[name].shape, args)
             elif rank == 4:
                 raise NotImplementedError('Rank 4 inputs not implemented')
             else:
@@ -118,106 +119,137 @@ def get_head_shapes(action_space, engine, agent_name):
     agent_class = get_agent_class(agent_name, engine)
     return agent_class.output_shape(action_space)
 
-
-def add_base_args(parser):
-    """
-    Common Arguments
-    """
+def _add_common_agent_args(parser: ArgumentParser):
     parser.add_argument(
-        '--learning-rate', '-lr', type=float, default=7e-4, metavar='LR',
+        '-al', '--learning-rate', type=float, default=7e-4,
         help='learning rate (default: 7e-4)'
     )
     parser.add_argument(
-        '--discount', type=float, default=0.99, metavar='D',
+        '-ad', '--discount', type=float, default=0.99,
         help='discount factor for rewards (default: 0.99)'
     )
-    parser.add_argument(
-        '-s', '--seed', type=int, default=0, metavar='S',
-        help='random seed (default: 0)'
+
+def _add_agent_args(subparser: ArgumentParser):
+    agent_parsers = []
+    for agent, agent_parser_fn in AGENT_ARG_PARSE.items():
+        parser_agent = subparser.add_parser(agent)
+        agent_group = parser_agent.add_argument_group('Agent Args')
+        _add_common_agent_args(agent_group)
+        agent_parser_fn(agent_group)
+        agent_parsers.append(parser_agent)
+    return agent_parsers
+
+def _add_network_args(parser: ArgumentParser):
+    subparser = parser.add_argument_group('Network Args')
+    subparser.add_argument(
+        '-nv', '--network-vision', default='FourConv'
     )
-    parser.add_argument(
-        '-n', '--nb-env', type=int, default=32, metavar='N',
-        help='number of envs to run in parallel (default: 32)'
+    subparser.add_argument(
+        '-nd', '--network-discrete', default='Identity'
     )
-    parser.add_argument(
-        '-mel', '--max-episode-length', type=int, default=10000, metavar='MEL',
-        help='maximum length of an episode (default: 10000)'
+    subparser.add_argument(
+        '-nb', '--network-body', default='LSTM'
     )
-    parser.add_argument(
-        '--env-id', default='PongNoFrameskip-v4',
+    subparser.add_argument(
+        '--normalize', type=parse_bool, nargs='?', const=True, default=True,
+        help='Applies batch norm between linear/convolutional layers and layer norm for LSTMs (default: True)'
+    )
+
+def _add_reload_args(parser: ArgumentParser):
+    subparser = parser.add_argument_group('Reload Args')
+    # Reload from save
+    subparser.add_argument(
+        '-ln', '--load-network', default='',
+        help='Load network from this path. Sets initial step count'
+    )
+    subparser.add_argument(
+        '-lo', '--load-optimizer', default='',
+        help='Load optimizer from this path'
+    )
+
+def _add_env_args(parser: ArgumentParser):
+    subparser = parser.add_argument_group('Environment Args')
+    subparser.add_argument(
+        '-e', '--env-id', default='PongNoFrameskip-v4',
         help='environment to train on (default: PongNoFrameskip-v4)'
     )
-    parser.add_argument(
-        '--log-dir', default='/tmp/adept_logs/',
-        help='folder to save logs. (default: /tmp/adept_logs)'
+    subparser.add_argument(
+        '-en', '--env-nb', type=int, default=32,
+        help='number of envs to run in parallel (default: 32)'
     )
-    parser.add_argument(
-        '-mts', '--max-train-steps', type=int, default=10e6, metavar='MTS',
-        help='number of steps to train for (default: 10e6)'
-    )
-    parser.add_argument(
-        '--nb-top-model', type=int, default=3, metavar='N',
-        help='number of top models to save per epoch'
-    )
-    parser.add_argument(
-        '--epoch-len', type=int, default=1e6, metavar='FREQ',
-        help='save top models every FREQ steps'
-    )
-    parser.add_argument(
-        '-sf', '--summary-frequency', default=10, metavar='FREQ',
-        help='write tensorboard summaries every FREQ seconds'
-    )
-    parser.add_argument(
-        '-t', '--tag', default='',
-        help='identify your experiment with a tag that gets prepended to experiment log directory'
-    )
-
-    """
-    Env Arguments
-    """
-    # Atari
-    parser.add_argument(
-        '--zscore-norm-env', type=parse_bool, nargs='?', const=True, default=False,
-        help='Normalize the environment using running statistics'
-    )
-    parser.add_argument(
-        '--skip-rate', type=int, default=4,
+    subparser.add_argument(
+        '-es', '--skip-rate', type=int, default=4,
         help='frame skip rate (default: 4)'
     )
-
-    """
-    Agent Arguments
-    """
-    parser.add_argument(
-        '-na', '--normalize-advantage', type=parse_bool, nargs='?', const=True, default=False,
-        help='normalize the advantage'
+    subparser.add_argument(
+        '-em', '--max-episode-length', type=int, default=10000, metavar='MEL',
+        help='maximum length of an episode (default: 10000)'
     )
-    parser.add_argument(
-        '-gae', '--generalized-advantage-estimation', type=parse_bool, nargs='?', const=True, default=True,
-        help='use generalized advantage estimation'
-    )
-    parser.add_argument(
-        '--tau', type=float, default=1.00,
-        help='parameter for GAE (default: 1.00)'
-    )
-    # Actor Critic
-    parser.add_argument(
-        '--exp-length', '--nb-rollout', type=int, default=20,
-        help='number of rollouts or size of experience replay'
+    subparser.add_argument(
+        '-ez', '--env-zscore', type=parse_bool, nargs='?', const=True, default=False,
+        help='Normalize the environment using running statistics'
     )
 
+def _add_common_args(parser: ArgumentParser):
+    _add_env_args(parser)
+    _add_network_args(parser)
+    _add_reload_args(parser)
     """
-    Network Arguments
+    Common Arguments
     """
-    parser.add_argument(
-        '--normalize', type=parse_bool, nargs='?', const=True, default=True,
-        help='applies batch norm between linear/convolutional layers and layer norm for LSTMs'
+    subparser = parser.add_argument_group('Common Args')
+    subparser.add_argument(
+        '-cl', '--log-dir', default='/tmp/adept_logs/',
+        help='Folder to save logs. (default: /tmp/adept_logs)'
+    )
+    subparser.add_argument(
+        '-ct', '--tag', default='',
+        help='Identify your experiment with a tag that gets prepended to the experiment log directory'
+    )
+    subparser.add_argument(
+        '-cm', '--max-train-steps', type=int, default=10e6,
+        help='Number of steps to train for (default: 10e6)'
+    )
+    subparser.add_argument(
+        '-ce', '--epoch-len', type=int, default=1e6, metavar='FREQ',
+        help='Save models every FREQ steps'
+    )
+    subparser.add_argument(
+        '-cf', '--summary-frequency', default=10,
+        help='Write tensorboard summaries every FREQ seconds'
+    )
+    subparser.add_argument(
+        '--seed', type=int, default=0,
+        help='Random seed (default: 0)'
+    )
+    subparser.add_argument(
+        '--profile',
+        type=parse_bool,
+        nargs='?',
+        const=True,
+        default=False,
+        help='displays profiling tree after 10e3 steps (default: False)'
+    )
+    subparser.add_argument(
+        '--debug',
+        type=parse_bool,
+        nargs='?',
+        const=True,
+        default=False,
+        help=
+        'debug mode sends the logs to /tmp/ and overrides number of workers to 3 (default: False)'
     )
 
-    # Attention
-    parser.add_argument(
-        '--nb-head', type=int, default=1,
-        help='number of attention heads. unused if no attention in network.'
-    )
+def _add_args_to_parsers(arg_fn, parsers):
+    return [arg_fn(x) for x in parsers]
+
+def add_base_args(parser: ArgumentParser, additional_args_fn=None):
+    # TODO: there must be a better way of adding args to subparsers while keeping the help message
+    # TODO: some agents may not run in certain modes not sure the best way to handle this
+    subparser_agent = parser.add_subparsers(title='Agents', dest='agent')
+    subparser_agent.required = True
+    agent_parsers = _add_agent_args(subparser_agent)
+    _add_args_to_parsers(_add_common_args, agent_parsers)
+    _add_args_to_parsers(additional_args_fn, agent_parsers)
 
     return parser


### PR DESCRIPTION
Fixes #6 
Args are now base on subcommands from the agent. So that each agent can have it's own separate args. Argparse doesn't make this very clean since it creates multiple parsers with each needing to add the base args but it's all contained in script helpers. 

Add support for loading network/optimizer -ln -lo respectively. Also splits the network file name to set the initial step count.

Some breaking changes for args:
nb-env -> env-nb
vision-network -> network-vision
discrete-network -> network-discrete